### PR TITLE
Bump version to 0.1.16 and enhance type handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c-two"
-version = "0.1.15"
+version = "0.1.16"
 description = "A python server to support communication between CRM and Component processes."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/c_two/message/client.py
+++ b/src/c_two/message/client.py
@@ -1,5 +1,4 @@
 import zmq
-import time
 import struct
 from . import globals
 from .transferable import get_transferable

--- a/tests/component.test.py
+++ b/tests/component.test.py
@@ -41,4 +41,8 @@ if __name__ == '__main__':
         parents = com.get_parent_keys(levels, global_ids)
         for parent in parents:
             print('Parent:', parent)
+        
+        # Test get_active_grid_infos
+        levels, global_ids = com.get_active_grid_infos()
+        print(len(levels), len(global_ids))
     

--- a/tests/component/__init__.py
+++ b/tests/component/__init__.py
@@ -17,5 +17,6 @@ def get_parent_keys(crm: IGrid, levels: list[int], global_ids: list[int]) -> lis
     return keys
 
 @cc.compo.runtime.connect
-def get_active_grid_render_info(crm: IGrid):
-    pass
+def get_active_grid_infos(crm: IGrid) -> tuple[list[int], list[int]]:
+    levels, global_ids = crm.get_active_grid_infos()
+    return levels, global_ids

--- a/tests/crm/__init__.py
+++ b/tests/crm/__init__.py
@@ -488,4 +488,5 @@ class Grid(IGrid):
             tuple[list[int], list[int]]: active grids' global ids and levels
         """
         active_grids = self.grids[self.grids[ATTR_ACTIVATE] == True]
+        # print(active_grids.index.get_level_values(0).tolist(), active_grids.index.get_level_values(1).tolist())
         return active_grids.index.get_level_values(0).tolist(), active_grids.index.get_level_values(1).tolist()


### PR DESCRIPTION
Update the version number and improve type hinting in `meta.py`. Clean up imports in `client.py`, enhance error handling in `transferable.py`, and add tests for `get_active_grid_infos`.