### PR TITLE
Enhance defaultTransferableFactory for tuple return type

### DIFF
--- a/src/c_two/message/transferable.py
+++ b/src/c_two/message/transferable.py
@@ -166,7 +166,10 @@ def defaultTransferableFactory(func, is_input: bool):
                         return tuple(ordered_args) if len(ordered_args) != 1 else ordered_args[0]
                     else:
                         # Direct args tuple
-                        return unpickled
+                        if isinstance(unpickled, tuple):
+                            return unpickled
+                        else:
+                            return (unpickled,)
                         
                 except Exception as e:
                     raise ValueError(f"Failed to deserialize input data for {func.__name__}: {e}")


### PR DESCRIPTION
Ensure that unpickled data is consistently returned as a tuple, improving the handling of deserialized data.