### PR TITLE
Remove flush=True from logger info in KeyboardInterrupt handling

### DIFF
--- a/src/c_two/message/server.py
+++ b/src/c_two/message/server.py
@@ -32,7 +32,7 @@ class Server:
             try:
                 threading.Event().wait(check_interval)
             except KeyboardInterrupt:
-                logger.info('\nKeyboardInterrupt received.\nStopping CRM server...', flush=True)
+                logger.info('\nKeyboardInterrupt received.\nStopping CRM server...')
                 self._cleanup(f'Cleaning up...')
                 self._termination_event.set()
     


### PR DESCRIPTION
Eliminate the flush parameter from the logger's info method to streamline logging during KeyboardInterrupt events in the CRM server.