### PR TITLE
Refactor CRM connection logic and enhance auto_transfer functionality

### DIFF
--- a/src/c_two/crm/meta.py
+++ b/src/c_two/crm/meta.py
@@ -61,7 +61,7 @@ def icrm(cls: T) -> T:
     decorated_methods = {}
     for name, value in cls.__dict__.items():
         if isfunction(value) and name not in ('__dict__', '__weakref__', '__module__', '__qualname__', '__init__'):
-            decorated_methods[name] = auto_transfer(value)
+            decorated_methods[name] = auto_transfer('->', value)
     
     # Define a new class with ICRMMeta metaclass that inherits from the original class
     class_name = cls.__name__
@@ -120,6 +120,6 @@ def iicrm(cls):
     # Decorate implemented methods with @auto_transfer
     for name, value in cls.__dict__.items():
         if isfunction(value) and name in base_class.__dict__:
-            setattr(cls, name, auto_transfer(value))
-    
+            setattr(cls, name, auto_transfer('<-', value))
+
     return cls

--- a/src/c_two/message/transferable.py
+++ b/src/c_two/message/transferable.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import pickle
 import struct
@@ -333,7 +334,7 @@ def transfer(input: str | None = None, output: str | None = None) -> callable:
     
     return decorator
 
-def auto_transfer(func = None) -> callable:
+def auto_transfer(direction: str, func = None) -> callable:
 
     def create_wrapper(func: callable) -> callable:
 
@@ -421,9 +422,14 @@ def auto_transfer(func = None) -> callable:
         @wraps(func)
         def final_wrapper(*args, **kwargs):
              return wrapped_func(*args, **kwargs)
-
-        final_wrapper.__origin__ = func
-        return final_wrapper
+            
+        if direction == '->':
+            return final_wrapper
+        elif direction == '<-':
+            func.__wrapped__ = final_wrapper
+            return func
+        else:
+            raise ValueError(f'Invalid direction value: {direction}. Expected "->" or "<-".')
 
     if func is None:
         return create_wrapper


### PR DESCRIPTION
Streamline the CRM connection logic by simplifying the connection method and removing unnecessary local instance handling. Enhance the `auto_transfer` decorator to support directional transfers, improving method wrapping for better clarity and functionality. Adjust logging for server termination to provide clearer messages.