### PR TITLE
Include uv.lock in version control for reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-# uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.


### PR DESCRIPTION
Ensure that uv.lock is included in version control to improve reproducibility, particularly for binary packages.