### PR TITLE
Refactor response handling in HttpClient, MemoryClient, and ZmqClient

### DIFF
--- a/src/c_two/rpc/http/http_client.py
+++ b/src/c_two/rpc/http/http_client.py
@@ -73,25 +73,10 @@ class HttpClient(BaseClient):
                 raise error.CompoClientError(f'HTTP error {response.status_code}')
                 
             full_response = response.content
+            return full_response
             
         except requests.RequestException as e:
             raise error.CompoClientError(f'HTTP request failed: {e}')
-        
-        # Deserialize Event
-        event = Event.deserialize(full_response)
-        if event.tag != EventTag.CRM_REPLY:
-            raise error.CompoClientError(f'Unexpected event tag: {event.tag}. Expected: {EventTag.CRM_REPLY}')
-
-        # Deserialize error and result
-        sub_responses = parse_message(event.data)
-        if len(sub_responses) != 2:
-            raise error.CompoDeserializeOutput(f'Expected exactly 2 sub-messages (error and result), got {len(sub_responses)}')
-
-        err = error.CCError.deserialize(sub_responses[0])
-        if err:
-            raise err
-        
-        return sub_responses[1]
     
     def terminate(self):
         """Close the HTTP session."""

--- a/src/c_two/rpc/zmq/zmq_client.py
+++ b/src/c_two/rpc/zmq/zmq_client.py
@@ -66,21 +66,7 @@ class ZmqClient(BaseClient):
         # Wait for response
         full_response = self.socket.recv()
         
-        # Deserialize Event
-        event = Event.deserialize(full_response)
-        if event.tag != EventTag.CRM_REPLY:
-            raise error.CompoClientError(f'Unexpected event tag: {event.tag}. Expected: {EventTag.CRM_REPLY}')
-        
-        # Deserialize error
-        sub_responses = parse_message(event.data)
-        if len(sub_responses) != 2:
-            raise error.CompoDeserializeOutput(f'Expected exactly 2 sub-messages (error and result), got {len(sub_responses)}')
-
-        err = error.CCError.deserialize(sub_responses[0])
-        if err:
-            raise err
-        
-        return sub_responses[1]
+        return full_response
 
     @staticmethod
     def ping(server_address: str, timeout: float = 0.5) -> bool:


### PR DESCRIPTION
Streamline response handling by removing unnecessary deserialization steps and improving the retrieval of response data. This enhances the efficiency of the relay method across multiple client implementations.