### PR TITLE
Refactor event logging and update test address to TCP

### DIFF
--- a/src/c_two/rpc/event/event.py
+++ b/src/c_two/rpc/event/event.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 from enum import Enum, unique
 from dataclasses import dataclass
-
+import logging
 from ... import error
 from ..util.encoding import add_length_prefix, parse_message
+
+logger = logging.getLogger(__name__)
 
 class CompletionType(Enum):
     OP_REQUEST = 'op_request'       # request for a queue operation
@@ -43,9 +45,9 @@ class Event:
                 raise ValueError('Event content is empty')
 
             tag_bytes, data = parse_message(content)
-            # 打印为16进制
-            print('tag:', tag_bytes.hex())
-            print('data:', data.hex())
+            
+            logger.info('tag: %s', tag_bytes.hex())
+            logger.info('data: %s', data.hex())
             return Event(tag=EventTag(tag_bytes.tobytes().decode('utf-8')), data=data)
 
         except Exception as e:

--- a/src/c_two/rpc/event/event.py
+++ b/src/c_two/rpc/event/event.py
@@ -43,6 +43,9 @@ class Event:
                 raise ValueError('Event content is empty')
 
             tag_bytes, data = parse_message(content)
+            # 打印为16进制
+            print('tag:', tag_bytes.hex())
+            print('data:', data.hex())
             return Event(tag=EventTag(tag_bytes.tobytes().decode('utf-8')), data=data)
 
         except Exception as e:

--- a/tests/component.test.py
+++ b/tests/component.test.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     HTTP_ADDRESS = 'http://localhost:5556/?node-key=tempParentPath_tempChildPath'
     HTTP_ADDRESS = 'http://localhost:5556/api/?node-key=tempParentPath_tempChildPath'
 
-    TEST_ADDRESS = MEMORY_ADDRESS
+    TEST_ADDRESS = TCP_ADDRESS
 
     # Check if CRM is running
     if cc.rpc.Client.ping(TEST_ADDRESS):

--- a/tests/crm.test.py
+++ b/tests/crm.test.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     HTTP_ADDRESS = 'http://localhost:5556'
     HTTP_ADDRESS = 'http://localhost:5556/api/?node-key=tempParentPath_tempChildPath'
 
-    TEST_ADDRESS = MEMORY_ADDRESS
+    TEST_ADDRESS = TCP_ADDRESS
 
     # Grid parameters
     # epsg = 2326


### PR DESCRIPTION
Enhance event logging by replacing print statements with logging and update the test address to use TCP instead of MEMORY.