### PR TITLE
Update version to 0.2.7 and fix bug in icrm decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# C-Two (Greenhouse v0.2.6)
+# C-Two (Greenhouse v0.2.7)
 
 [![PyPI version](https://badge.fury.io/py/c-two.svg)](https://badge.fury.io/py/c-two)
 
@@ -8,10 +8,8 @@
 
 C-Two is a **Remote Procedure Call (RPC) framework** that enables resource-oriented classes to be remotely invoked across different processes or machines. It is specifically designed for distributed resource computation systems. The framework provides a structured abstraction layer that enables remote method calling between **Components** and **Core Resource Models (CRMs)** with automatic serialization and protocol-agnostic communication.
 
-## What's New in v0.2.6
-- More convenient implementation for Core Resource Models (no need to inherit from a base ICRM class and decorate with `@iicrm`).
-- More specific ICRM identification with namespace and versioning support.
-- Servers now support graceful shutdown with cleanup callbacks.
+## What's New in v0.2.7
+- Fixed a bug in the `@icrm` decorator that made type hinting into ICRMMeta forcefully.
 
 ## WIP
 - Support for function validation between CRM and ICRM.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c-two"
-version = "0.2.6"
+version = "0.2.7"
 description = "C-Two is a resource-RPC framework that enables resource-oriented classes to be remotely invoked across different processes or machines."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/c_two/__init__.py
+++ b/src/c_two/__init__.py
@@ -9,7 +9,7 @@ from .compo import runtime
 from .crm.meta import icrm
 from .rpc.transferable import transferable
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 LOGO_ASCII ="""
                                                   

--- a/src/c_two/crm/meta.py
+++ b/src/c_two/crm/meta.py
@@ -34,7 +34,7 @@ def icrm(*, namespace: str = 'cc', version: str = '0.1.0'):
         A class that has all the attributes of the original class plus a static
         'connect' method that creates and returns instances connected to a remote service.
     """
-    def icrm_wrapper(cls: Type[ICRM]) -> ICRMMeta:
+    def icrm_wrapper(cls: Type[ICRM]) -> Type[ICRM]:
         # Validate namespace and version
         if not namespace:
             raise ValueError('Namespace of ICRM cannot be empty.')

--- a/tests/icrm/__init__.py
+++ b/tests/icrm/__init__.py
@@ -215,7 +215,7 @@ class GridKeys:
 
 # Define ICRM ###########################################################
 
-@cc.icrm
+@cc.icrm(namespace='icrm', version='0.1.0')
 class IGrid:
     """
     IGrid


### PR DESCRIPTION
Bump the version to 0.2.7 and resolve a bug in the `@icrm` decorator that affected type hinting.