### PR TITLE
Update connection names and improve HTTP client URL encoding

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -19,7 +19,7 @@ from grid.grid_contract import (
 
 def main():
     # Connect to the remote server via IPC
-    grid = cc.connect(Grid, name='grid')
+    grid = cc.connect(Grid, name='examples/grid')
     print(f'Connected (mode: {grid.client._mode})\n')
 
     # Say hello

--- a/examples/crm_process.py
+++ b/examples/crm_process.py
@@ -21,10 +21,7 @@ from grid.grid_contract import Grid
 
 logging.basicConfig(level=logging.DEBUG)
 
-
 def main():
-    # Init the Grid CRM (same as old server.py)
-
     # Init the Grid CRM (same as old server.py)
     epsg = 2326
     first_size = [64.0, 64.0]
@@ -35,7 +32,7 @@ def main():
     grid = NestedGrid(epsg, bounds, first_size, subdivide_rules)
 
     # Register — one line replaces ServerConfig + Server + start()
-    cc.register(Grid, grid, name='grid')
+    cc.register(Grid, grid, name='examples/grid')
     print(f'Grid CRM registered at {cc.server_address()}')
 
     # Block until SIGINT/SIGTERM, then auto-shutdown via atexit.

--- a/examples/relay_client.py
+++ b/examples/relay_client.py
@@ -25,7 +25,7 @@ from grid.grid_contract import Grid, GridAttribute
 
 def main():
     # Connect via HTTP relay — same API as IPC, different address.
-    grid = cc.connect(Grid, name='grid')
+    grid = cc.connect(Grid, name='examples/grid')
     print(f'[Client] Connected via HTTP (mode: {grid.client._mode})\n')
 
     # ── Hello ─────────────────────────────────────────────────────

--- a/src/c_two/_native/Cargo.lock
+++ b/src/c_two/_native/Cargo.lock
@@ -74,12 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,15 +743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,15 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1005,36 +981,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1042,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1054,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1712,12 +1684,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/src/c_two/_native/Cargo.lock
+++ b/src/c_two/_native/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "clap",
  "futures",
  "parking_lot",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/src/c_two/_native/Cargo.toml
+++ b/src/c_two/_native/Cargo.toml
@@ -16,3 +16,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 parking_lot = "0.12"
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/src/c_two/_native/bridge/c2-ffi/Cargo.toml
+++ b/src/c_two/_native/bridge/c2-ffi/Cargo.toml
@@ -20,11 +20,6 @@ c2-http = { path = "../../transport/c2-http", features = ["relay"] }
 c2-ipc = { path = "../../transport/c2-ipc" }
 c2-server = { path = "../../transport/c2-server" }
 parking_lot = { workspace = true }
-pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
-
-[profile.release]
-opt-level = 3
-lto = "fat"
-codegen-units = 1

--- a/src/c_two/_native/bridge/c2-ffi/src/client_ffi.rs
+++ b/src/c_two/_native/bridge/c2-ffi/src/client_ffi.rs
@@ -4,7 +4,7 @@
 //! `RustClientPool` — a process-level pool of shared clients.
 //!
 //! **GIL handling**: all blocking operations release the GIL via
-//! `py.allow_threads()`.  `#[pyclass(frozen)]` ensures thread-safety
+//! `py.detach()`. `#[pyclass(frozen)]` ensures thread-safety
 //! for free-threading builds.
 
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -316,7 +316,7 @@ impl PyRustClient {
         };
         let seg_size = config.pool_segment_size as usize;
         let addr = address.to_string();
-        let client = py.allow_threads(move || {
+        let client = py.detach(move || {
             let mut pc = c2_mem::PoolConfig::default();
             pc.segment_size = seg_size;
             let pool = Arc::new(parking_lot::Mutex::new(
@@ -353,7 +353,7 @@ impl PyRustClient {
             match inner.pool_alloc_and_write(data) {
                 Ok(alloc) => {
                     let data_size = data.len();
-                    let result = py.allow_threads(move || {
+                    let result = py.detach(move || {
                         inner.call_prealloc(&route, &method, &alloc, data_size)
                     });
                     return match result {
@@ -384,9 +384,9 @@ impl PyRustClient {
         }
 
         // Fallback: inline/chunked path (small payloads or pool unavailable).
-        // to_vec() is needed because allow_threads requires owned data.
+        // to_vec() is needed because detach requires owned data.
         let payload = data.to_vec();
-        let result = py.allow_threads(move || inner.call(&route, &method, &payload));
+        let result = py.detach(move || inner.call(&route, &method, &payload));
 
         match result {
             Ok(response_data) => {
@@ -468,7 +468,7 @@ impl PyRustClientPool {
         let addr = address.to_string();
         let pool = self.inner;
         let client = py
-            .allow_threads(move || pool.acquire(&addr, None))
+            .detach(move || pool.acquire(&addr, None))
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         Ok(PyRustClient { inner: client })
     }
@@ -528,7 +528,7 @@ impl PyRustClientPool {
 
     /// Shut down all pooled clients immediately.
     fn shutdown_all(&self, py: Python<'_>) {
-        py.allow_threads(|| self.inner.shutdown_all());
+        py.detach(|| self.inner.shutdown_all());
     }
 
     /// Number of active entries in the pool.

--- a/src/c_two/_native/bridge/c2-ffi/src/http_ffi.rs
+++ b/src/c_two/_native/bridge/c2-ffi/src/http_ffi.rs
@@ -53,8 +53,7 @@ impl PyRustHttpClient {
         let method = method_name.to_string();
         let payload = data.to_vec();
 
-        let result =
-            py.allow_threads(move || inner.call(&route, &method, &payload));
+        let result = py.detach(move || inner.call(&route, &method, &payload));
 
         match result {
             Ok(bytes) => Ok(PyBytes::new(py, &bytes)),
@@ -72,7 +71,7 @@ impl PyRustHttpClient {
     /// Health check — GET /health on the relay.
     fn health(&self, py: Python<'_>) -> PyResult<bool> {
         let inner = Arc::clone(&self.inner);
-        py.allow_threads(move || inner.health())
+        py.detach(move || inner.health())
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
@@ -119,7 +118,7 @@ impl PyRustHttpClientPool {
         let url = base_url.to_string();
         let pool = self.inner;
         let client = py
-            .allow_threads(move || pool.acquire(&url))
+            .detach(move || pool.acquire(&url))
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         Ok(PyRustHttpClient { inner: client })
     }
@@ -131,7 +130,7 @@ impl PyRustHttpClientPool {
 
     /// Shut down all pooled HTTP clients immediately.
     fn shutdown_all(&self, py: Python<'_>) {
-        py.allow_threads(|| self.inner.shutdown_all());
+        py.detach(|| self.inner.shutdown_all());
     }
 
     /// Number of active entries in the pool.

--- a/src/c_two/_native/bridge/c2-ffi/src/mem_ffi.rs
+++ b/src/c_two/_native/bridge/c2-ffi/src/mem_ffi.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, RwLock};
 
 /// Python-visible pool configuration.
-#[pyclass(name = "PoolConfig", frozen)]
+#[pyclass(name = "PoolConfig", frozen, skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyPoolConfig {
     #[pyo3(get)]
@@ -118,7 +118,7 @@ impl From<&PyPoolConfig> for PoolConfig {
 }
 
 /// Python-visible allocation result.
-#[pyclass(name = "PoolAlloc", frozen)]
+#[pyclass(name = "PoolAlloc", frozen, skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyPoolAlloc {
     #[pyo3(get)]
@@ -156,7 +156,7 @@ impl From<PoolAllocation> for PyPoolAlloc {
 }
 
 /// Python-visible pool statistics.
-#[pyclass(name = "PoolStats", frozen)]
+#[pyclass(name = "PoolStats", frozen, skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyPoolStats {
     #[pyo3(get)]

--- a/src/c_two/_native/bridge/c2-ffi/src/relay_ffi.rs
+++ b/src/c_two/_native/bridge/c2-ffi/src/relay_ffi.rs
@@ -5,13 +5,14 @@
 //! OS thread with its own tokio runtime.
 //!
 //! **GIL handling**: All methods that block (start, stop, register, etc.)
-//! release the Python GIL via `py.allow_threads()` so the Python ServerV2
+//! release the Python GIL via `py.detach()` so the Python ServerV2
 //! asyncio loop can continue processing connections during handshake.
 
 use parking_lot::Mutex;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::types::PyAny;
 
 use c2_http::relay::server::RelayServer;
 use c2_config::RelayConfig;
@@ -79,9 +80,9 @@ impl PyNativeRelay {
                 return Err(PyRuntimeError::new_err("Relay is already running"));
             }
             state.config.clone()
-        }; // lock dropped before allow_threads
+        }; // lock dropped before detach
         let server = py
-            .allow_threads(|| RelayServer::start(config))
+            .detach(|| RelayServer::start(config))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to start relay: {e}")))?;
         self.state.lock().server = Some(server);
         Ok(())
@@ -97,8 +98,8 @@ impl PyNativeRelay {
                 .server
                 .take()
                 .ok_or_else(|| PyRuntimeError::new_err("Relay is not running"))?
-        }; // lock dropped before allow_threads
-        py.allow_threads(|| server.stop())
+        }; // lock dropped before detach
+        py.detach(|| server.stop())
             .map_err(|e| PyRuntimeError::new_err(format!("Stop failed: {e}")))?;
         Ok(())
     }
@@ -106,12 +107,12 @@ impl PyNativeRelay {
     /// Register a new upstream IPC connection.
     ///
     /// Releases the GIL while connecting to the upstream (UDS + handshake).
-    /// The Mutex is acquired inside `allow_threads` to prevent GIL↔Mutex
+    /// The Mutex is acquired inside `detach` to prevent GIL↔Mutex
     /// deadlock.
     fn register_upstream(&self, py: Python<'_>, name: &str, address: &str) -> PyResult<()> {
         let name = name.to_string();
         let address = address.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let state = self.state.lock();
             let server = state
                 .server
@@ -127,7 +128,7 @@ impl PyNativeRelay {
     /// Releases the GIL while waiting for the command to complete.
     fn unregister_upstream(&self, py: Python<'_>, name: &str) -> PyResult<()> {
         let name = name.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let state = self.state.lock();
             let server = state
                 .server
@@ -141,9 +142,9 @@ impl PyNativeRelay {
     /// List all registered routes.
     ///
     /// Returns a list of dicts with "name" and "address" keys.
-    fn list_routes(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn list_routes(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let routes = py
-            .allow_threads(|| {
+            .detach(|| {
                 let state = self.state.lock();
                 let server = state
                     .server

--- a/src/c_two/_native/bridge/c2-ffi/src/server_ffi.rs
+++ b/src/c_two/_native/bridge/c2-ffi/src/server_ffi.rs
@@ -5,8 +5,8 @@
 //! OS thread with its own tokio runtime.
 //!
 //! **GIL handling**: `PyCrmCallback::invoke()` acquires the GIL internally
-//! (called from `spawn_blocking` inside tokio).  All blocking `PyServer`
-//! methods release the GIL via `py.allow_threads()`.
+//! (called from `spawn_blocking` inside tokio). All blocking `PyServer`
+//! methods release the GIL via `py.detach()`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use parking_lot::Mutex;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyTuple};
+use pyo3::types::{PyAny, PyBytes, PyDict, PyTuple};
 
 use c2_mem::MemPool;
 use c2_config::{BaseIpcConfig, ServerIpcConfig};
@@ -30,12 +30,12 @@ use crate::shm_buffer::PyShmBuffer;
 // ---------------------------------------------------------------------------
 
 struct PyCrmCallback {
-    py_callable: PyObject,
-    response_pool_obj: PyObject,
+    py_callable: Py<PyAny>,
+    response_pool_obj: Py<PyAny>,
 }
 
-// SAFETY: PyObject is Send when accessed only under the GIL.
-// `invoke()` always acquires the GIL via `Python::with_gil` before
+// SAFETY: Py<PyAny> is Send when accessed only under the GIL.
+// `invoke()` always acquires the GIL via `Python::attach` before
 // touching `py_callable`.
 unsafe impl Send for PyCrmCallback {}
 unsafe impl Sync for PyCrmCallback {}
@@ -50,7 +50,7 @@ impl CrmCallback for PyCrmCallback {
         // re-creating PyMemPool on every call. Trait requires it for non-FFI impls.
         _response_pool: Arc<parking_lot::RwLock<MemPool>>,
     ) -> Result<ResponseMeta, CrmError> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Convert RequestData → PyShmBuffer
             let shm_buf = match request {
                 RequestData::Inline(data) => PyShmBuffer::from_inline(data),
@@ -67,14 +67,19 @@ impl CrmCallback for PyCrmCallback {
                 .map_err(|e| CrmError::InternalError(format!("failed to create ShmBuffer: {e}")))?;
 
             // Call Python: dispatcher(route_name, method_idx, shm_buffer, response_pool)
-            let args = (route_name, method_idx, buf_obj, &self.response_pool_obj);
+            let args = (
+                route_name,
+                method_idx,
+                buf_obj,
+                self.response_pool_obj.bind(py),
+            );
             match self.py_callable.call1(py, args) {
                 Ok(result) => parse_response_meta(py, result),
                 Err(e) => {
                     // Check for .error_bytes attribute (CrmCallError from Python).
                     let val = e.value(py);
                     if let Ok(attr) = val.getattr("error_bytes") {
-                        if let Ok(b) = attr.downcast::<PyBytes>() {
+                        if let Ok(b) = attr.cast::<PyBytes>() {
                             return Err(CrmError::UserError(b.as_bytes().to_vec()));
                         }
                     }
@@ -167,7 +172,7 @@ impl PyServer {
         &self,
         py: Python<'_>,
         name: &str,
-        dispatcher: PyObject,
+        dispatcher: Py<PyAny>,
         method_names: Vec<String>,
         access_map: &Bound<'_, PyDict>,
     ) -> PyResult<()> {
@@ -189,7 +194,7 @@ impl PyServer {
         }
 
         // Create PyMemPool wrapping the server's response pool
-        let response_pool_obj: PyObject = {
+        let response_pool_obj: Py<PyAny> = {
             let pool_arc = self.inner.response_pool_arc();
             let py_pool = PyMemPool::from_arc(pool_arc);
             Py::new(py, py_pool)?.into_any()
@@ -212,7 +217,7 @@ impl PyServer {
 
         // Register requires async; use a short-lived runtime if the main
         // one hasn't started, or block_on the existing runtime's handle.
-        py.allow_threads(move || {
+        py.detach(move || {
             let rt_guard = self.rt.lock();
             if let Some(rt) = rt_guard.as_ref() {
                 rt.block_on(server.register_route(route));
@@ -237,7 +242,7 @@ impl PyServer {
         // Build the runtime while NOT holding the Mutex (avoid GIL↔Mutex deadlock).
         let server = Arc::clone(&self.inner);
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
                 .enable_all()
@@ -271,7 +276,7 @@ impl PyServer {
     fn shutdown(&self, py: Python<'_>) -> PyResult<()> {
         let server = Arc::clone(&self.inner);
 
-        py.allow_threads(|| {
+        py.detach(|| {
             server.shutdown();
 
             let rt = {
@@ -292,7 +297,7 @@ impl PyServer {
         let server = Arc::clone(&self.inner);
         let name = name.to_string();
 
-        py.allow_threads(move || {
+        py.detach(move || {
             let rt_guard = self.rt.lock();
             if let Some(rt) = rt_guard.as_ref() {
                 Ok(rt.block_on(server.unregister_route(&name)))
@@ -329,19 +334,21 @@ impl PyServer {
 /// - `None` → `ResponseMeta::Empty`
 /// - `bytes` → `ResponseMeta::Inline(vec)`
 /// - `(seg_idx: int, offset: int, data_size: int, is_dedicated: bool)` → `ResponseMeta::ShmAlloc`
-fn parse_response_meta(py: Python<'_>, result: PyObject) -> Result<ResponseMeta, CrmError> {
+fn parse_response_meta(py: Python<'_>, result: Py<PyAny>) -> Result<ResponseMeta, CrmError> {
+    let result = result.bind(py);
+
     // None → Empty
-    if result.is_none(py) {
+    if result.is_none() {
         return Ok(ResponseMeta::Empty);
     }
 
     // bytes → Inline
-    if let Ok(bytes) = result.downcast_bound::<PyBytes>(py) {
+    if let Ok(bytes) = result.cast::<PyBytes>() {
         return Ok(ResponseMeta::Inline(bytes.as_bytes().to_vec()));
     }
 
     // tuple (seg_idx, offset, data_size, is_dedicated) → ShmAlloc
-    if let Ok(tup) = result.downcast_bound::<PyTuple>(py) {
+    if let Ok(tup) = result.cast::<PyTuple>() {
         if tup.len() != 4 {
             return Err(CrmError::InternalError(format!(
                 "expected 4-element tuple (seg_idx, offset, data_size, is_dedicated), got {}-element tuple",

--- a/src/c_two/_native/transport/c2-http/Cargo.toml
+++ b/src/c_two/_native/transport/c2-http/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 parking_lot = { workspace = true }
+percent-encoding = "2"
 thiserror = "2"
 
 # Relay-only dependencies (behind feature gate)

--- a/src/c_two/_native/transport/c2-http/src/client/client.rs
+++ b/src/c_two/_native/transport/c2-http/src/client/client.rs
@@ -3,7 +3,21 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use thiserror::Error;
+
+/// Characters allowed unencoded in URL path segments — matches Python's
+/// ``urllib.parse.quote(s, safe='')`` so a `/` in a CRM route name is
+/// percent-encoded as `%2F` rather than splitting the path.
+const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+fn encode_segment(s: &str) -> String {
+    utf8_percent_encode(s, PATH_SEGMENT).to_string()
+}
 
 // ── Shared tokio runtime ────────────────────────────────────────────────
 
@@ -84,7 +98,12 @@ impl HttpClient {
         method_name: &str,
         data: &[u8],
     ) -> Result<Vec<u8>, HttpError> {
-        let url = format!("{}/{}/{}", self.base_url, route_name, method_name);
+        let url = format!(
+            "{}/{}/{}",
+            self.base_url,
+            encode_segment(route_name),
+            encode_segment(method_name),
+        );
         let resp = self
             .client
             .post(&url)

--- a/src/c_two/transport/registry.py
+++ b/src/c_two/transport/registry.py
@@ -41,6 +41,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
+from urllib.parse import quote as _urlquote
 from typing import TypeVar
 
 from c_two.config.ipc import ServerIPCConfig, ClientIPCConfig, build_server_config, build_client_config
@@ -385,8 +386,10 @@ class _ProcessRegistry:
                     if ipc_addr:
                         address = ipc_addr
                     else:
-                        relay_url = route.get("relay_url", "")
-                        address = f"{relay_url}/{name}"
+                        # HTTP base URL is just the relay; the Rust HTTP
+                        # client appends `/{route_name}/{method_name}` on
+                        # each call.
+                        address = route.get("relay_url", "")
 
                     if address.startswith(('http://', 'https://')):
                         client = self._http_pool.acquire(address)
@@ -727,7 +730,7 @@ class _ProcessRegistry:
         import json
         import urllib.request
 
-        url = f'{relay_addr.rstrip("/")}/_resolve/{name}'
+        url = f'{relay_addr.rstrip("/")}/_resolve/{_urlquote(name, safe="")}'
         try:
             req = urllib.request.Request(url)
             with urllib.request.urlopen(req, timeout=5) as resp:

--- a/tests/integration/test_http_relay.py
+++ b/tests/integration/test_http_relay.py
@@ -271,6 +271,37 @@ class TestCcConnectHttp:
         cc.close(crm)
         assert registry._http_pool.refcount(relay_url) == 0
 
+    def test_connect_http_with_slash_in_name(self):
+        """CRM names containing '/' (toodle-style resource paths) work over HTTP relay.
+
+        Regression: axum's single-segment ``Path<String>`` extractor would
+        404 on a raw ``/_resolve/a/b`` and split ``/{name}/{method}``
+        wrong. Both the Python registry and the Rust HTTP client now
+        percent-encode ``/`` as ``%2F``.
+        """
+        from c_two._native import NativeRelay
+
+        slashed_name = 'toodle/grid/0'
+        cc.register(Hello, HelloImpl(), name=slashed_name)
+        ipc_addr = cc.server_address()
+
+        http_port = 19000 + _next_id()
+        relay = NativeRelay(f'0.0.0.0:{http_port}')
+        relay.start()
+        relay_url = f'http://127.0.0.1:{http_port}'
+        try:
+            _wait_for_relay(relay_url)
+            relay.register_upstream(slashed_name, ipc_addr)
+
+            # Forced HTTP mode (address explicitly set).
+            crm = cc.connect(Hello, name=slashed_name, address=relay_url)
+            try:
+                assert crm.greeting('Slash') == 'Hello, Slash!'
+            finally:
+                cc.close(crm)
+        finally:
+            relay.stop()
+
 
 # ---------------------------------------------------------------------------
 # Control-plane endpoint tests


### PR DESCRIPTION
Enhance connection names by prefixing them with 'examples/' and improve URL encoding in the HTTP client to handle slashes correctly. Update dependencies and refine GIL handling in FFI bindings for better performance.