### PR TITLE
Update CI workflow and project version to 0.4.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
     groups:
       rust-minor-and-patch:
         update-types:
@@ -16,8 +17,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    rebase-strategy: "disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -19,18 +20,32 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Skip redundant Dependabot matrix leg
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && matrix.python != '3.12'
+        run: echo "Skipping this matrix leg for Dependabot pull requests"
+
       - uses: actions/setup-python@v5
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
         with:
           python-version: ${{ matrix.python }}
 
       - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
+
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
+        with:
+          workspaces: src/c_two/_native -> target
 
       - uses: astral-sh/setup-uv@v6
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
 
       - name: Install dependencies & build native extension
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
         run: uv sync
 
       - name: Run tests
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || matrix.python == '3.12'
         run: uv run pytest tests/ -q --timeout=30
         env:
           C2_RELAY_ADDRESS: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c-two"
-version = "0.4.4"
+version = "0.4.5"
 description = "C-Two is a resource-RPC framework that enables resource-oriented classes to be remotely invoked across different processes or machines."
 readme = "README.md"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Enhance the CI workflow by skipping redundant Dependabot matrix legs and adding a merge_group trigger. Update the project version to 0.4.5 and ensure the rebase strategy is disabled for all package ecosystems.