### PR TITLE
Refactor: enhance security by removing ipc_address from peer routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c-two"
-version = "0.4.5"
+version = "0.4.6"
 description = "C-Two is a resource-RPC framework that enables resource-oriented classes to be remotely invoked across different processes or machines."
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/src/c_two/_native/transport/c2-http/src/relay/background.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/background.rs
@@ -169,7 +169,12 @@ async fn anti_entropy_loop(state: Arc<RelayState>, cancel: CancellationToken) {
             if let Ok(resp_env) = resp.json::<PeerEnvelope>().await {
                 if let PeerMessage::DigestDiff { entries, extra: _ } = resp_env.message {
                     for diff_entry in entries {
-                        state.register_peer_route(diff_entry.into());
+                        // Defense-in-depth: scrub ipc_address from incoming
+                        // peer routes — the path is local to the sender.
+                        let mut entry: crate::relay::types::RouteEntry =
+                            diff_entry.into();
+                        entry.ipc_address = None;
+                        state.register_peer_route(entry);
                     }
                 }
             }
@@ -240,7 +245,10 @@ async fn dead_peer_probe_loop(state: Arc<RelayState>, cancel: CancellationToken)
                     if let Ok(resp_env) = resp.json::<PeerEnvelope>().await {
                         if let PeerMessage::DigestDiff { entries, extra: _ } = resp_env.message {
                             for diff_entry in entries {
-                                state.register_peer_route(diff_entry.into());
+                                let mut entry: crate::relay::types::RouteEntry =
+                                    diff_entry.into();
+                                entry.ipc_address = None;
+                                state.register_peer_route(entry);
                             }
                         }
                     }

--- a/src/c_two/_native/transport/c2-http/src/relay/peer_handlers.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/peer_handlers.rs
@@ -29,14 +29,18 @@ pub async fn handle_peer_announce(
     }
     match envelope.message {
         PeerMessage::RouteAnnounce {
-            name, relay_id, relay_url, ipc_address,
+            name, relay_id, relay_url, ipc_address: _,
             crm_ns, crm_ver, registered_at,
         } => {
             if relay_id == state.relay_id() {
                 return StatusCode::OK;
             }
+            // Defense-in-depth: ipc_address is a private local path on the
+            // sending relay; never store it in our PEER routes regardless of
+            // what the wire said.
             state.register_peer_route(RouteEntry {
-                name, relay_id, relay_url, ipc_address,
+                name, relay_id, relay_url,
+                ipc_address: None,
                 crm_ns, crm_ver,
                 locality: Locality::Peer,
                 registered_at,
@@ -74,6 +78,12 @@ pub async fn handle_peer_join(
             status: PeerStatus::Alive,
         });
         let mut snapshot = state.full_snapshot();
+        // Strip ipc_address from every route before sending — these paths
+        // are local to this relay's filesystem and cannot be reached by the
+        // joiner directly; they must use relay_url instead.
+        for entry in snapshot.routes.iter_mut() {
+            entry.ipc_address = None;
+        }
         // Include ourselves so the joiner can add us as a peer.
         snapshot.peers.push(PeerSnapshot {
             relay_id: state.relay_id().to_string(),
@@ -163,11 +173,13 @@ pub async fn handle_peer_digest(
                         if let Some(entry) = all_routes.iter()
                             .find(|e| e.name == key.0 && e.relay_id == key.1)
                         {
+                            // Strip ipc_address — it's a local-only path on
+                            // this relay's filesystem.
                             diff_entries.push(crate::relay::peer::DigestDiffEntry {
                                 name: entry.name.clone(),
                                 relay_id: entry.relay_id.clone(),
                                 relay_url: entry.relay_url.clone(),
-                                ipc_address: entry.ipc_address.clone(),
+                                ipc_address: None,
                                 crm_ns: entry.crm_ns.clone(),
                                 crm_ver: entry.crm_ver.clone(),
                                 registered_at: entry.registered_at,
@@ -190,7 +202,11 @@ pub async fn handle_peer_digest(
         }
         PeerMessage::DigestDiff { entries, extra } => {
             for diff in entries {
-                state.register_peer_route(diff.into());
+                // Defense-in-depth: scrub ipc_address from incoming peer
+                // routes — that path belongs to the sender's local filesystem.
+                let mut entry: RouteEntry = diff.into();
+                entry.ipc_address = None;
+                state.register_peer_route(entry);
             }
             for (name, relay_id) in extra {
                 state.unregister_peer_route(&name, &relay_id);

--- a/src/c_two/_native/transport/c2-http/src/relay/route_table.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/route_table.rs
@@ -190,6 +190,9 @@ impl RouteTable {
                 continue; // Don't overwrite our own LOCAL routes.
             }
             entry.locality = Locality::Peer;
+            // Defense-in-depth: ipc_address is a private local path on the
+            // sender's filesystem; never store it for PEER routes.
+            entry.ipc_address = None;
             let key = (entry.name.clone(), entry.relay_id.clone());
             self.routes.insert(key, entry);
         }
@@ -216,7 +219,13 @@ impl RouteTable {
         }
     }
 
-    /// Route digest for anti-entropy: (name, relay_id) → hash(registered_at, ipc_address).
+    /// Route digest for anti-entropy: (name, relay_id) → hash of fields that
+    /// every relay sees the same way.
+    ///
+    /// **Must not include `ipc_address`**: the route owner stores the local
+    /// UDS path, but peers (correctly) store `None`. Hashing the path would
+    /// make local-vs-peer digests permanently disagree and cause anti-entropy
+    /// to churn the same route forever.
     pub fn route_digest(&self) -> HashMap<(String, String), u64> {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
@@ -226,7 +235,9 @@ impl RouteTable {
             .map(|(key, entry)| {
                 let mut hasher = DefaultHasher::new();
                 entry.registered_at.to_bits().hash(&mut hasher);
-                entry.ipc_address.hash(&mut hasher);
+                entry.relay_url.hash(&mut hasher);
+                entry.crm_ns.hash(&mut hasher);
+                entry.crm_ver.hash(&mut hasher);
                 (key.clone(), hasher.finish())
             })
             .collect()
@@ -374,12 +385,29 @@ mod tests {
     }
 
     #[test]
-    fn route_digest_changes_on_update() {
+    fn route_digest_stable_when_only_ipc_address_changes() {
+        // Critical anti-entropy invariant: ipc_address must NOT contribute
+        // to the digest, because the owning relay stores Some(...) but
+        // peers store None — if it contributed, the two views would never
+        // converge and anti-entropy would loop forever.
         let mut rt = RouteTable::new("relay-a".into());
         rt.register_route(local_entry("grid", "relay-a"));
         let d1 = rt.route_digest();
         let mut entry = local_entry("grid", "relay-a");
         entry.ipc_address = Some("ipc://changed".into());
+        rt.register_route(entry);
+        let d2 = rt.route_digest();
+        let key = ("grid".to_string(), "relay-a".to_string());
+        assert_eq!(d1[&key], d2[&key]);
+    }
+
+    #[test]
+    fn route_digest_changes_on_relay_url_update() {
+        let mut rt = RouteTable::new("relay-a".into());
+        rt.register_route(local_entry("grid", "relay-a"));
+        let d1 = rt.route_digest();
+        let mut entry = local_entry("grid", "relay-a");
+        entry.relay_url = "http://changed:9090".into();
         rt.register_route(entry);
         let d2 = rt.route_digest();
         let key = ("grid".to_string(), "relay-a".to_string());
@@ -390,5 +418,44 @@ mod tests {
     fn resolve_missing_name_returns_empty() {
         let rt = RouteTable::new("relay-a".into());
         assert!(rt.resolve("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn merge_snapshot_strips_ipc_address_from_peer_routes() {
+        // Sender's local route includes an ipc_address (its own UDS path).
+        let mut rt_a = RouteTable::new("relay-a".into());
+        rt_a.register_route(local_entry("grid", "relay-a"));
+        let snapshot = rt_a.full_snapshot();
+        // Local snapshot still carries ipc_address — that's intentional;
+        // scrubbing happens at the wire boundary (handle_peer_join) and at
+        // merge time on the receiver below.
+
+        let mut rt_b = RouteTable::new("relay-b".into());
+        rt_b.merge_snapshot(snapshot);
+
+        let resolved = rt_b.resolve("grid");
+        assert_eq!(resolved.len(), 1);
+        assert!(
+            resolved[0].ipc_address.is_none(),
+            "PEER routes must not expose sender's local UDS path",
+        );
+        assert_eq!(resolved[0].relay_url, "http://relay-a:8080");
+    }
+
+    #[test]
+    fn to_route_info_strips_ipc_address_for_peer() {
+        // Even if a Peer entry somehow carries an ipc_address, to_route_info
+        // must not leak it to clients (defense-in-depth).
+        let mut entry = peer_entry("grid", "relay-b", 1000.0);
+        entry.ipc_address = Some("ipc://leaked".into());
+        let info = entry.to_route_info();
+        assert!(info.ipc_address.is_none());
+    }
+
+    #[test]
+    fn to_route_info_keeps_ipc_address_for_local() {
+        let entry = local_entry("grid", "relay-a");
+        let info = entry.to_route_info();
+        assert!(info.ipc_address.is_some());
     }
 }

--- a/src/c_two/_native/transport/c2-http/src/relay/router.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/router.rs
@@ -100,14 +100,15 @@ async fn handle_register(
 
     let entry = state.register_upstream(name.clone(), address, crm_ns, crm_ver, client);
 
-    // Gossip announce to peers
+    // Gossip announce to peers — strip ipc_address since it's a local UDS
+    // path on THIS relay's filesystem and is meaningless to remote peers.
     let envelope = PeerEnvelope::new(
         state.relay_id(),
         PeerMessage::RouteAnnounce {
             name: entry.name.clone(),
             relay_id: entry.relay_id.clone(),
             relay_url: entry.relay_url.clone(),
-            ipc_address: entry.ipc_address.clone(),
+            ipc_address: None,
             crm_ns: entry.crm_ns.clone(),
             crm_ver: entry.crm_ver.clone(),
             registered_at: entry.registered_at,
@@ -166,10 +167,24 @@ async fn handle_unregister(
 }
 
 /// `GET /_routes` — list all registered routes.
+///
+/// Intentionally omits `ipc_address` even for LOCAL routes: this endpoint is
+/// reachable by anyone who can hit the relay's HTTP port, and the local UDS
+/// path is filesystem-private to the owning host.
 async fn handle_list_routes(State(state): State<Arc<RelayState>>) -> impl IntoResponse {
     let routes: Vec<serde_json::Value> = state.list_routes()
         .into_iter()
-        .map(|r| serde_json::json!({"name": r.name, "address": r.ipc_address.unwrap_or_default()}))
+        .map(|r| serde_json::json!({
+            "name": r.name,
+            "relay_id": r.relay_id,
+            "relay_url": r.relay_url,
+            "locality": match r.locality {
+                crate::relay::types::Locality::Local => "local",
+                crate::relay::types::Locality::Peer => "peer",
+            },
+            "crm_ns": r.crm_ns,
+            "crm_ver": r.crm_ver,
+        }))
         .collect();
     Json(serde_json::json!({"routes": routes}))
 }

--- a/src/c_two/_native/transport/c2-http/src/relay/state.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/state.rs
@@ -123,6 +123,13 @@ impl RelayState {
     // -- PEER route operations (gossip) --
 
     pub fn register_peer_route(&self, entry: RouteEntry) {
+        // Never overwrite a LOCAL route with a peer-sourced one. Anti-entropy
+        // can echo our own routes back to us with `relay_id == our id`; if we
+        // accepted those, we'd silently replace `Locality::Local` with
+        // `Locality::Peer` and lose our own ipc_address.
+        if entry.relay_id == self.route_table.read().relay_id() {
+            return;
+        }
         self.route_table.write().register_route(entry);
     }
 
@@ -237,5 +244,30 @@ mod tests {
         assert_eq!(state.resolve("remote").len(), 1);
         state.unregister_peer_route("remote", "peer-1");
         assert!(state.resolve("remote").is_empty());
+    }
+
+    #[test]
+    fn register_peer_route_does_not_overwrite_local() {
+        // Anti-entropy can echo our own routes back to us. The peer-route
+        // entry path MUST refuse anything carrying our own relay_id, or it
+        // would silently demote a Local route (with ipc_address) to a Peer
+        // route (without ipc_address) and break local IPC dispatch.
+        let state = RelayState::new(test_config(), null_disseminator());
+        let client = Arc::new(IpcClient::new("ipc://grid"));
+        state.register_upstream("grid".into(), "ipc://grid".into(),
+            "test.ns".into(), "0.1.0".into(), client);
+
+        // Echo of our own route arriving via DigestDiff with our relay_id.
+        state.register_peer_route(RouteEntry {
+            name: "grid".into(), relay_id: "test-relay".into(),
+            relay_url: "http://elsewhere:8080".into(), ipc_address: None,
+            crm_ns: "test.ns".into(), crm_ver: "0.1.0".into(),
+            locality: Locality::Peer, registered_at: 1000.0,
+        });
+
+        let routes = state.resolve("grid");
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].ipc_address.as_deref(), Some("ipc://grid"),
+            "echoed peer route must not overwrite our LOCAL route");
     }
 }

--- a/src/c_two/_native/transport/c2-http/src/relay/types.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/types.rs
@@ -33,10 +33,16 @@ pub struct RouteInfo {
 
 impl RouteEntry {
     pub fn to_route_info(&self) -> RouteInfo {
+        // `ipc_address` is private to the owning relay's filesystem; only
+        // expose it for LOCAL routes. PEER routes go through `relay_url`.
+        let ipc_address = match self.locality {
+            Locality::Local => self.ipc_address.clone(),
+            Locality::Peer => None,
+        };
         RouteInfo {
             name: self.name.clone(),
             relay_url: self.relay_url.clone(),
-            ipc_address: self.ipc_address.clone(),
+            ipc_address,
             crm_ns: self.crm_ns.clone(),
             crm_ver: self.crm_ver.clone(),
         }

--- a/src/c_two/transport/registry.py
+++ b/src/c_two/transport/registry.py
@@ -42,6 +42,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from urllib.parse import quote as _urlquote
+from urllib.parse import urlparse as _urlparse
 from typing import TypeVar
 
 from c_two.config.ipc import ServerIPCConfig, ClientIPCConfig, build_server_config, build_client_config
@@ -55,6 +56,31 @@ from ..crm.meta import MethodAccess
 
 CRM = TypeVar('CRM')
 log = logging.getLogger(__name__)
+
+
+_LOOPBACK_HOSTS = frozenset({
+    'localhost',
+    '127.0.0.1',
+    '::1',
+    '0.0.0.0',
+})
+
+
+def _is_local_relay_url(relay_url: str) -> bool:
+    """Return True if ``relay_url`` points at a relay on the same host.
+
+    Used to decide whether a route's ``ipc_address`` (a local UDS path on
+    the relay's filesystem) is reachable from this client. When the relay
+    sits at a non-loopback address it must be a remote machine, and the
+    UDS path is meaningless to us.
+    """
+    if not relay_url:
+        return False
+    try:
+        host = (_urlparse(relay_url).hostname or '').lower()
+    except Exception:
+        return False
+    return host in _LOOPBACK_HOSTS
 
 
 def _physical_memory() -> int | None:
@@ -382,14 +408,30 @@ class _ProcessRegistry:
             last_error = None
             for route in routes:
                 try:
+                    relay_url = route.get("relay_url", "") or ""
                     ipc_addr = route.get("ipc_address")
-                    if ipc_addr:
+                    # ipc_address is a UDS path on the relay's filesystem —
+                    # only usable when this client is on the same host as the
+                    # owning relay. Detect that via loopback / empty relay_url
+                    # (i.e. it's our local relay reporting one of its own
+                    # routes). Otherwise we MUST go through the relay's HTTP
+                    # endpoint instead.
+                    if ipc_addr and _is_local_relay_url(relay_url):
                         address = ipc_addr
-                    else:
+                    elif relay_url:
                         # HTTP base URL is just the relay; the Rust HTTP
                         # client appends `/{route_name}/{method_name}` on
                         # each call.
-                        address = route.get("relay_url", "")
+                        address = relay_url
+                    elif ipc_addr:
+                        # Last resort: no relay_url known, fall back to
+                        # ipc_addr (legacy behaviour).
+                        address = ipc_addr
+                    else:
+                        last_error = ResourceUnavailable(
+                            f"Route for {name!r} has neither relay_url nor ipc_address",
+                        )
+                        continue
 
                     if address.startswith(('http://', 'https://')):
                         client = self._http_pool.acquire(address)


### PR DESCRIPTION
Remove `ipc_address` from peer routes and responses to improve security. This change prevents exposure of local filesystem paths to remote peers, ensuring that only relevant information is shared. Additionally, update related logic to handle routes appropriately without the `ipc_address`. Version updated to 0.4.6.