### PR TITLE
Add C2_RELAY_USE_PROXY environment variable for relay traffic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@
 # Anti-entropy digest exchange interval in seconds (default: 60.0)
 # C2_RELAY_ANTI_ENTROPY_INTERVAL=60.0
 
+# Whether c-two relay traffic should honor system HTTP_PROXY / HTTPS_PROXY
+# env vars. Default: false (relay is private mesh infrastructure; proxies
+# can corrupt %2F in URL path segments and leak control data).
+# Set to 1/true to opt in.
+# C2_RELAY_USE_PROXY=0
+
 # --------------------------------------------------------------------------
 # Shared Memory (SHM)
 # --------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.7] — 2026-04-22
+
+### Fixed
+
+- Cross-machine relay traffic no longer goes through system `HTTP_PROXY` /
+  `HTTPS_PROXY` by default. Forward proxies are known to normalize
+  percent-encoded `%2F` in URL path segments to `/`, which broke resource
+  names containing `/` (e.g., `nhri/simulator`) and silently rerouted CRM
+  call traffic through the proxy. Both the Python registry's `urllib`
+  client and all Rust `reqwest::Client` instances (CRM HTTP client, relay
+  mesh disseminator, anti-entropy / failure-detection / route-pull loops,
+  upstream IPC client builder) now bypass system proxies. Set
+  `C2_RELAY_USE_PROXY=1` to opt back in.
+
+  The `c3 registry list-routes / resolve / peers` admin commands also
+  bypass system proxies for consistency with runtime traffic. If
+  `reqwest::ClientBuilder::build()` ever fails, c-two now panics rather
+  than silently falling back to a proxy-respecting `Client::default()`.
+  The `C2_RELAY_USE_PROXY` flag is read directly from `os.environ` /
+  `std::env` on every call so Python and Rust layers always see a
+  consistent view (no cached pydantic settings).
+
+### Added
+
+- `C2_RELAY_USE_PROXY` env var (default: `false`) controlling whether
+  c-two relay HTTP traffic honors system proxy environment variables.
+
 ## [0.4.3] — 2026-04-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c-two"
-version = "0.4.6"
+version = "0.4.7"
 description = "C-Two is a resource-RPC framework that enables resource-oriented classes to be remotely invoked across different processes or machines."
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/src/c_two/_native/transport/c2-http/src/client/client.rs
+++ b/src/c_two/_native/transport/c2-http/src/client/client.rs
@@ -69,7 +69,7 @@ impl HttpClient {
         timeout_secs: f64,
         max_connections: usize,
     ) -> Result<Self, HttpError> {
-        let client = reqwest::Client::builder()
+        let client = crate::relay_client_builder()
             .timeout(Duration::from_secs_f64(timeout_secs))
             .pool_max_idle_per_host(max_connections)
             .build()

--- a/src/c_two/_native/transport/c2-http/src/lib.rs
+++ b/src/c_two/_native/transport/c2-http/src/lib.rs
@@ -7,3 +7,26 @@ pub mod client;
 
 #[cfg(feature = "relay")]
 pub mod relay;
+
+/// Should reqwest clients in c-two honor system HTTP_PROXY env vars?
+///
+/// Default: **false** — c-two relay traffic is private mesh infrastructure,
+/// and routing it through a forward proxy is known to corrupt percent-encoded
+/// path segments (e.g., `%2F` in resource names) and leak internal control
+/// data. Set `C2_RELAY_USE_PROXY=1` to opt in to using the system proxy.
+pub fn relay_use_proxy() -> bool {
+    matches!(
+        std::env::var("C2_RELAY_USE_PROXY")
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1") | Some("true") | Some("True") | Some("TRUE") | Some("yes") | Some("YES"),
+    )
+}
+
+/// Build a reqwest::ClientBuilder pre-configured for c-two relay traffic.
+/// Applies `.no_proxy()` unless the user opted in via `C2_RELAY_USE_PROXY=1`.
+pub fn relay_client_builder() -> reqwest::ClientBuilder {
+    let b = reqwest::Client::builder();
+    if relay_use_proxy() { b } else { b.no_proxy() }
+}

--- a/src/c_two/_native/transport/c2-http/src/relay/background.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/background.rs
@@ -133,10 +133,10 @@ async fn anti_entropy_loop(state: Arc<RelayState>, cancel: CancellationToken) {
     ticker.tick().await;
     let mut round_robin_idx: usize = 0;
 
-    let client = reqwest::Client::builder()
+    let client = crate::relay_client_builder()
         .timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+            .build()
+        .expect("c-two: failed to build reqwest Client for relay traffic");
 
     loop {
         tokio::select! {
@@ -201,10 +201,10 @@ async fn dead_peer_probe_loop(state: Arc<RelayState>, cancel: CancellationToken)
     let mut ticker = tokio::time::interval(interval);
     ticker.tick().await;
 
-    let client = reqwest::Client::builder()
+    let client = crate::relay_client_builder()
         .timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+            .build()
+        .expect("c-two: failed to build reqwest Client for relay traffic");
 
     loop {
         tokio::select! {
@@ -265,10 +265,10 @@ async fn seed_retry_loop(state: Arc<RelayState>, cancel: CancellationToken) {
     let mut ticker = tokio::time::interval(interval);
     ticker.tick().await;
 
-    let client = reqwest::Client::builder()
+    let client = crate::relay_client_builder()
         .timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+            .build()
+        .expect("c-two: failed to build reqwest Client for relay traffic");
 
     loop {
         tokio::select! {

--- a/src/c_two/_native/transport/c2-http/src/relay/disseminator.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/disseminator.rs
@@ -20,10 +20,10 @@ pub struct FullBroadcast {
 impl FullBroadcast {
     pub fn new() -> Self {
         Self {
-            http_client: reqwest::Client::builder()
+            http_client: crate::relay_client_builder()
                 .timeout(std::time::Duration::from_secs(5))
-                .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            .build()
+                .expect("c-two: failed to build reqwest Client for relay traffic"),
         }
     }
 

--- a/src/c_two/_native/transport/c2-http/src/relay/server.rs
+++ b/src/c_two/_native/transport/c2-http/src/relay/server.rs
@@ -186,10 +186,10 @@ impl RelayServer {
         if !state.config().seeds.is_empty() {
             let s = state.clone();
             tokio::spawn(async move {
-                let client = reqwest::Client::builder()
+                let client = crate::relay_client_builder()
                     .timeout(std::time::Duration::from_secs(5))
-                    .build()
-                    .unwrap_or_else(|_| reqwest::Client::new());
+            .build()
+                    .expect("c-two: failed to build reqwest Client for relay traffic");
                 for seed_url in &s.config().seeds {
                     let join_url = format!("{seed_url}/_peer/join");
                     let envelope = PeerEnvelope::new(

--- a/src/c_two/cli.py
+++ b/src/c_two/cli.py
@@ -3,6 +3,10 @@ import logging
 import re
 import signal
 import sys
+
+# Reuse the registry's proxy-bypass-aware urllib opener so
+# CLI admin commands honor the same C2_RELAY_USE_PROXY policy as runtime.
+from c_two.transport.registry import _relay_urlopen
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -267,7 +271,7 @@ def registry_list_routes(relay):
 
     url = f'{relay.rstrip("/")}/_routes'
     try:
-        with urllib.request.urlopen(url, timeout=5) as resp:
+        with _relay_urlopen(urllib.request.Request(url), timeout=5) as resp:
             routes = json.loads(resp.read())
             if not routes:
                 click.echo('No routes registered.')
@@ -290,7 +294,7 @@ def registry_resolve(relay, name):
 
     url = f'{relay.rstrip("/")}/_resolve/{name}'
     try:
-        with urllib.request.urlopen(url, timeout=5) as resp:
+        with _relay_urlopen(urllib.request.Request(url), timeout=5) as resp:
             routes = json.loads(resp.read())
             for route in routes:
                 click.echo(json.dumps(route, indent=2))
@@ -314,7 +318,7 @@ def registry_peers(relay):
 
     url = f'{relay.rstrip("/")}/_peers'
     try:
-        with urllib.request.urlopen(url, timeout=5) as resp:
+        with _relay_urlopen(urllib.request.Request(url), timeout=5) as resp:
             peer_list = json.loads(resp.read())
             if not peer_list:
                 click.echo('No peers known.')

--- a/src/c_two/config/settings.py
+++ b/src/c_two/config/settings.py
@@ -27,6 +27,10 @@ class C2Settings(BaseSettings):
     relay_advertise_url: str | None = None       # C2_RELAY_ADVERTISE_URL
     relay_idle_timeout: int | None = None        # C2_RELAY_IDLE_TIMEOUT
     relay_anti_entropy_interval: float = 60.0    # C2_RELAY_ANTI_ENTROPY_INTERVAL
+    # NOTE: C2_RELAY_USE_PROXY is read directly via os.environ in
+    # transport/registry.py and Rust crate::relay_use_proxy(). It is NOT a
+    # pydantic field here because both layers must agree on its value at
+    # call time, not at settings-instantiation time.
 
     @property
     def relay_seed_list(self) -> list[str]:

--- a/src/c_two/transport/registry.py
+++ b/src/c_two/transport/registry.py
@@ -37,13 +37,48 @@ import logging
 import os
 import signal
 import sys
+import os
 import threading
 import time
+import urllib.request
 import uuid
 from dataclasses import dataclass
 from urllib.parse import quote as _urlquote
 from urllib.parse import urlparse as _urlparse
 from typing import TypeVar
+
+
+# Build once: an opener that BYPASSES system HTTP_PROXY for all relay traffic.
+# Rationale: the c-two relay is private mesh infrastructure on user-controlled
+# hosts. Routing relay traffic through a corporate / dev HTTP proxy causes
+# subtle bugs (e.g., proxies normalize percent-encoded `%2F` in path segments
+# to `/`, breaking resource names that contain `/`). It is also a privacy /
+# correctness hazard to leak internal mesh control traffic to a third-party
+# proxy. An empty ProxyHandler({}) tells urllib to never use any proxy.
+#
+# Users who actually want to route relay traffic through the system proxy
+# (e.g., behind a forward proxy that doesn't normalize URLs) can opt in by
+# setting C2_RELAY_USE_PROXY=1.
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+def _relay_use_proxy() -> bool:
+    """Read C2_RELAY_USE_PROXY directly from the environment.
+
+    We read the env var at call time (not via the cached pydantic settings
+    object) so behavior matches the Rust side, which also reads the env on
+    every client creation. This avoids a confusing "Python and Rust
+    disagree" failure mode if the user mutates the env after import.
+    """
+    val = os.environ.get("C2_RELAY_USE_PROXY", "").strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def _relay_urlopen(req, timeout: float = 5.0):
+    """urlopen for relay traffic. Honors C2_RELAY_USE_PROXY (default: bypass)."""
+    if _relay_use_proxy():
+        return urllib.request.urlopen(req, timeout=timeout)
+    return _NO_PROXY_OPENER.open(req, timeout=timeout)
 
 from c_two.config.ipc import ServerIPCConfig, ClientIPCConfig, build_server_config, build_client_config
 from c_two.config.settings import settings
@@ -660,7 +695,6 @@ class _ProcessRegistry:
         if not relay_addr:
             return  # No relay configured — standalone mode.
 
-        import urllib.request
         import json
 
         payload = json.dumps({
@@ -678,7 +712,7 @@ class _ProcessRegistry:
                     headers={"Content-Type": "application/json"},
                     method="POST",
                 )
-                with urllib.request.urlopen(req, timeout=5) as resp:
+                with _relay_urlopen(req, timeout=5) as resp:
                     if resp.status in (200, 201):
                         log.info('Registered CRM %s with relay at %s',
                                  name, relay_addr)
@@ -696,7 +730,6 @@ class _ProcessRegistry:
     def _schedule_background_relay_register(self, name, ipc_address,
                                             crm_ns, crm_ver):
         """Background thread that keeps trying to register with relay."""
-        import urllib.request
         import json
 
         def retry_loop():
@@ -720,7 +753,7 @@ class _ProcessRegistry:
                         headers={"Content-Type": "application/json"},
                         method="POST",
                     )
-                    with urllib.request.urlopen(req, timeout=5):
+                    with _relay_urlopen(req, timeout=5):
                         log.info('Background relay register succeeded for %s',
                                  name)
                         return
@@ -737,7 +770,6 @@ class _ProcessRegistry:
             return
 
         import json
-        import urllib.request
 
         url = f'{relay_addr.rstrip("/")}/_unregister'
         body = json.dumps({'name': name}).encode()
@@ -748,7 +780,7 @@ class _ProcessRegistry:
                     headers={'Content-Type': 'application/json'},
                     method='POST',
                 )
-                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                with _relay_urlopen(req, timeout=timeout) as resp:
                     if resp.status in (200, 204):
                         log.info('Unregistered CRM %s from relay', name)
                         return
@@ -770,12 +802,11 @@ class _ProcessRegistry:
             raise RegistryUnavailable("No relay configured (set C2_RELAY_ADDRESS or call cc.set_relay())")
 
         import json
-        import urllib.request
 
         url = f'{relay_addr.rstrip("/")}/_resolve/{_urlquote(name, safe="")}'
         try:
             req = urllib.request.Request(url)
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with _relay_urlopen(req, timeout=5) as resp:
                 routes = json.loads(resp.read())
                 self._route_cache.put(name, routes)
                 return routes

--- a/tests/integration/test_http_relay.py
+++ b/tests/integration/test_http_relay.py
@@ -41,14 +41,18 @@ def _next_id() -> int:
 
 def _wait_for_relay(url: str, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            resp = httpx.get(f'{url}/health', timeout=0.5)
-            if resp.status_code == 200:
-                return
-        except Exception:
-            pass
-        time.sleep(0.1)
+    # trust_env=False disables HTTP_PROXY / HTTPS_PROXY env reading so that
+    # tests which set a black-hole proxy (test_relay_traffic_bypasses_system_proxy)
+    # can still poll the local relay's /health.
+    with httpx.Client(trust_env=False, timeout=0.5) as client:
+        while time.monotonic() < deadline:
+            try:
+                resp = client.get(f'{url}/health')
+                if resp.status_code == 200:
+                    return
+            except Exception:
+                pass
+            time.sleep(0.1)
     raise TimeoutError(f'Relay at {url} not ready after {timeout}s')
 
 
@@ -297,6 +301,49 @@ class TestCcConnectHttp:
             crm = cc.connect(Hello, name=slashed_name, address=relay_url)
             try:
                 assert crm.greeting('Slash') == 'Hello, Slash!'
+            finally:
+                cc.close(crm)
+        finally:
+            relay.stop()
+
+    def test_relay_traffic_bypasses_system_proxy(self, monkeypatch):
+        """All relay HTTP traffic must ignore HTTP_PROXY by default.
+
+        Regression: when a user sets HTTP_PROXY/HTTPS_PROXY (e.g. a corporate
+        forward proxy or a docker host proxy), Python urllib previously routed
+        relay control traffic through it, and proxies are known to normalize
+        percent-encoded ``%2F`` in URL paths to ``/`` — which then breaks
+        resource names containing ``/``. This test points HTTP_PROXY at a
+        black-hole address and verifies that name resolution + a CRM call
+        still succeed (i.e., proxy was bypassed).
+        """
+        from c_two._native import NativeRelay
+
+        # Black-hole proxy: connecting to TEST-NET-1 (RFC 5737) is guaranteed
+        # to time out / fail. If the request actually goes through the proxy,
+        # the test will fail loudly.
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            monkeypatch.setenv(var, 'http://192.0.2.1:9')
+        for var in ('no_proxy', 'NO_PROXY'):
+            monkeypatch.delenv(var, raising=False)
+
+        name = 'proxy/bypass/test'
+        cc.register(Hello, HelloImpl(), name=name)
+        ipc_addr = cc.server_address()
+
+        http_port = 19000 + _next_id()
+        relay = NativeRelay(f'0.0.0.0:{http_port}')
+        relay.start()
+        relay_url = f'http://127.0.0.1:{http_port}'
+        try:
+            _wait_for_relay(relay_url)
+            relay.register_upstream(name, ipc_addr)
+
+            # urllib resolve must succeed (registry's _relay_urlopen bypasses proxy).
+            crm = cc.connect(Hello, name=name, address=relay_url)
+            try:
+                # reqwest call must succeed (Rust HttpClient builder bypasses proxy).
+                assert crm.greeting('NoProxy') == 'Hello, NoProxy!'
             finally:
                 cc.close(crm)
         finally:


### PR DESCRIPTION
Introduce the `C2_RELAY_USE_PROXY` environment variable to control whether relay traffic honors system proxy settings. By default, relay traffic bypasses proxies to prevent issues with percent-encoded URL paths. Update the client builder and related components to respect this new setting. Ensure consistent behavior across Python and Rust layers.